### PR TITLE
correct logic for incoming edge reverse traversal

### DIFF
--- a/cog/torque.py
+++ b/cog/torque.py
@@ -309,7 +309,7 @@ class Graph:
                         adjacent_vertices.append(Vertex(v_adj).set_edge(predicate))
             elif direction == 'in':
                 in_record = self.cog.use_table(predicate).get(in_nodes(vertex.id))
-                if not in_record is not None:
+                if in_record is not None:
                     for v_adj in in_record.value:
                         adjacent_vertices.append(Vertex(v_adj).set_edge(predicate))
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='cogdb',
-      version='3.0.7',
+      version='3.0.8',
       description='Persistent Embedded Graph Database',
       url='http://github.com/arun1729/cog',
       author='Arun Mahendra',

--- a/test/test_torque.py
+++ b/test/test_torque.py
@@ -179,6 +179,11 @@ class TorqueTest(unittest.TestCase):
         actual = TorqueTest.g.v().has("<follows>", "<fred>").inc().all('e')
         self.assertTrue(expected == actual)
 
+    def test_torque_22(self):
+        expected = {'result': [{'id': '<bob>'}]}
+        actual = TorqueTest.g.v().hasr("<follows>", "<alice>").all()
+        self.assertEqual(expected, actual)
+
     @classmethod
     def tearDownClass(cls):
         TorqueTest.g.close()


### PR DESCRIPTION
Corrected the logic in Graph.__adjacent_vertices so incoming edges are processed only when a record exists, enabling proper reverse traversal

Added a dedicated unit test validating traversal through incoming edges with hasr, ensuring reverse edge filtering works as expected.