### PR TITLE
Add SPARQL 1.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,55 @@ g = Graph(graph_name="people")
 g.load_edgelist("/path/to/edgelist", "people")
 ```
 
+## SPARQL queries
+
+CogDB graphs can be queried with standard [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) — including joins, FILTER, OPTIONAL, UNION, aggregates and property paths — via an [rdflib](https://rdflib.readthedocs.io/) store adapter. SPARQL is optional; install it with:
+
+```
+pip install cogdb[sparql]
+```
+
+Torque and SPARQL query the same storage. A vertex written with `put()` is addressable in SPARQL as an IRI:
+
+```python
+from cog.torque import Graph
+g = Graph(graph_name="people")
+g.put("alice", "follows", "bob")
+g.put("bob", "follows", "fred")
+
+g.sparql("SELECT ?x WHERE { <alice> <follows> ?y . ?y <follows> ?x }")
+# {'head': {'vars': ['x']}, 'results': {'bindings': [{'x': {'type': 'uri', 'value': 'fred'}}]}}
+
+g.sparql("SELECT ?x WHERE { <alice> <follows>+ ?x }")   # property path (transitive)
+g.sparql("ASK { <alice> <follows> <bob> }")             # {'head': {}, 'boolean': True}
+```
+
+`sparql()` returns SELECT/ASK results in the [W3C SPARQL JSON results format](https://www.w3.org/TR/sparql11-results-json/), so any standard SPARQL tooling can consume them.
+
+#### Loading RDF files (Turtle, JSON-LD, RDF/XML, ...)
+
+```python
+g.load_rdf("people.ttl")                                 # format guessed from extension
+g.v("http://example.org/alice").out().all()              # visible to Torque too
+```
+
+Language tags and datatypes are preserved — `"chat"@fr` and `"chat"` stay distinct terms, and typed literals compare numerically:
+
+```python
+g.sparql('SELECT ?p WHERE { ?p <http://example.org/age> ?a FILTER(?a > 30) }')
+```
+
+#### Full rdflib access
+
+`g.rdf()` returns a live `rdflib.Graph` view over the CogDB graph for anything rdflib can do — serialization, JSON-LD export, SHACL validation via pySHACL, and so on:
+
+```python
+rg = g.rdf()
+rg.serialize("out.ttl", format="turtle")
+```
+
+The stored-string convention (how IRIs, literals and blank nodes map onto CogDB vertex ids) is documented in `cog/rdf_terms.py`.
+
 ## Config
 
 If no config is provided when creating a Cog instance, it will use the defaults:

--- a/README.md
+++ b/README.md
@@ -508,11 +508,7 @@ g.load_edgelist("/path/to/edgelist", "people")
 
 ## SPARQL queries
 
-CogDB graphs can be queried with standard [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) — including joins, FILTER, OPTIONAL, UNION, aggregates and property paths — via an [rdflib](https://rdflib.readthedocs.io/) store adapter. SPARQL is optional; install it with:
-
-```
-pip install cogdb[sparql]
-```
+CogDB graphs can be queried with standard [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) — including joins, FILTER, OPTIONAL, UNION, aggregates and property paths — via an [rdflib](https://rdflib.readthedocs.io/) store adapter, included by default.
 
 Torque and SPARQL query the same storage. A vertex written with `put()` is addressable in SPARQL as an IRI:
 

--- a/cog/rdf_store.py
+++ b/cog/rdf_store.py
@@ -1,0 +1,240 @@
+"""
+rdflib Store adapter for CogDB.
+
+CogStore exposes a cog.torque.Graph as an rdflib-compatible triple store,
+which gives CogDB full SPARQL 1.1 (SELECT, ASK, CONSTRUCT, DESCRIBE, property
+paths, aggregates, OPTIONAL/UNION/FILTER, ...) through rdflib's query engine,
+plus rdflib's parsers and serializers (Turtle, N-Triples, JSON-LD, RDF/XML).
+
+The adapter maps rdflib's pattern-at-a-time triples() calls onto CogDB's
+per-predicate adjacency tables, so bound lookups hit the same O(1) paths
+Torque's out()/inc() use:
+
+    (s, p, o)   membership test in s's out-set for p
+    (s, p, ?)   out-neighbors of s in p's table
+    (?, p, o)   in-neighbors of o in p's table
+    (?, p, ?)   scan of p's table
+    (.., ?, ..) the above, looped over every predicate table
+
+Terms are converted at this boundary — and only here — using cog.rdf_terms.
+
+Usage:
+    from cog.torque import Graph
+    g = Graph("my_graph")
+    g.sparql("SELECT ?x WHERE { <alice> <follows> ?x }")   # uses CogStore
+
+    # or explicitly, as a plugin:
+    import rdflib
+    rg = rdflib.Graph(store="cogdb")
+    rg.open("my_graph")
+"""
+import logging
+
+from rdflib.store import Store, VALID_STORE
+
+from cog.database import hash_predicate
+from cog.rdf_terms import decode_term, encode_term
+
+logger = logging.getLogger(__name__)
+
+
+class CogStore(Store):
+    """An rdflib Store backed by a cog.torque.Graph."""
+
+    context_aware = False
+    formula_aware = False
+    transaction_aware = False
+    graph_aware = False
+
+    def __init__(self, configuration=None, identifier=None):
+        """
+        :param configuration: a cog.torque.Graph instance, or a graph name
+            string (the plugin path: rdflib.Graph(store="cogdb").open("name")),
+            or None to open() later.
+        :param identifier: rdflib graph identifier (unused, kept for the
+            plugin protocol).
+        """
+        self.__namespace = {}
+        self.__prefix = {}
+        self.cog_graph = None
+        graph = None
+        if configuration is not None and not isinstance(configuration, str):
+            graph, configuration = configuration, None
+        super().__init__(configuration=configuration, identifier=identifier)
+        if graph is not None:
+            self._attach(graph)
+
+    # === Store lifecycle ===
+
+    def _attach(self, graph):
+        if getattr(graph, "_cloud", False):
+            raise NotImplementedError(
+                "SPARQL over cloud-mode graphs is not supported yet; "
+                "open the graph locally.")
+        self.cog_graph = graph
+
+    def open(self, configuration, create=False):
+        if isinstance(configuration, str) and configuration:
+            from cog.torque import Graph as CogGraph
+            self._attach(CogGraph(graph_name=configuration))
+        return VALID_STORE
+
+    def close(self, commit_pending_transaction=False):
+        pass  # the cog Graph owns its lifecycle
+
+    def _graph(self):
+        if self.cog_graph is None:
+            raise RuntimeError(
+                "CogStore is not attached to a graph; pass a cog.torque.Graph "
+                "to CogStore(...) or call open(graph_name).")
+        return self.cog_graph
+
+    # === CogDB access helpers ===
+
+    def _predicate_entries(self, pred=None):
+        """Yield (pred_hash, predicate_name) pairs.
+
+        With pred (an encoded predicate name) bound, yields at most one entry
+        and only if that predicate exists — a lookup on a missing predicate
+        must not create its table files. Unbound, yields every real predicate,
+        skipping CogDB-internal tables.
+        """
+        g = self._graph()
+        if pred is not None:
+            pred_hash = hash_predicate(pred)
+            if pred_hash in g.all_predicates:
+                yield pred_hash, pred
+            return
+        internal = {g.config.GRAPH_NODE_SET_TABLE_NAME,
+                    g.config.GRAPH_EDGE_SET_TABLE_NAME,
+                    g.config.EMBEDDING_SET_TABLE_NAME}
+        for pred_hash in g.all_predicates:
+            if pred_hash in internal:
+                continue
+            name = g._predicate_reverse_lookup_cache.get(pred_hash)
+            if name is None:
+                record = g.cog.use_namespace(g.graph_name).use_table(
+                    g.config.GRAPH_EDGE_SET_TABLE_NAME).get(pred_hash)
+                if record is None:
+                    continue
+                name = record.value
+                g._predicate_reverse_lookup_cache[pred_hash] = name
+            yield pred_hash, name
+
+    def _neighbors(self, pred_hash, node, direction):
+        """Adjacent vertex ids of node for one predicate, or None."""
+        g = self._graph()
+        mg = g._get_mg(pred_hash)
+        if mg is not None:
+            nbrs = mg.get_out(node) if direction == 'out' else mg.get_in(node)
+        else:
+            nbrs = g._disk_get_neighbors(pred_hash, node, direction)
+        if isinstance(nbrs, str):
+            # Single-value record ('s' type, created via put_new_edge):
+            # iterating it directly would yield characters.
+            return (nbrs,)
+        return nbrs
+
+    def _iter_edges(self, pred_hash):
+        """Yield (subject, object) stored-string pairs for one predicate."""
+        g = self._graph()
+        table = g.cog.get_table(pred_hash, g.graph_name)
+        for record in table.indexer.scanner(table.store):
+            key = record.key
+            if not isinstance(key, (bytes, bytearray)) or key[:1] != b'\x00':
+                continue  # only out-direction keys; \x01 mirrors them
+            subject = key[1:].decode('utf-8')
+            value = record.value
+            # scanner() re-wraps records with a default value_type, so
+            # branch on the runtime type: str is a single object, list/set
+            # is a materialized value chain.
+            if isinstance(value, str):
+                yield subject, value
+            else:
+                for obj in value:
+                    yield subject, obj
+
+    @staticmethod
+    def _contexts():
+        return iter(())
+
+    # === Store read interface ===
+
+    def triples(self, triple_pattern, context=None):
+        s, p, o = triple_pattern
+        g = self._graph()
+        g.cog.use_namespace(g.graph_name)
+
+        enc_s = encode_term(s) if s is not None else None
+        enc_p = encode_term(p) if p is not None else None
+        enc_o = encode_term(o) if o is not None else None
+
+        for pred_hash, pred_name in self._predicate_entries(enc_p):
+            p_term = p if p is not None else decode_term(pred_name)
+            if enc_s is not None and enc_o is not None:
+                nbrs = self._neighbors(pred_hash, enc_s, 'out')
+                if nbrs and enc_o in nbrs:
+                    yield (s, p_term, o), self._contexts()
+            elif enc_s is not None:
+                nbrs = self._neighbors(pred_hash, enc_s, 'out')
+                if nbrs:
+                    for obj in nbrs:
+                        yield (s, p_term, decode_term(obj)), self._contexts()
+            elif enc_o is not None:
+                nbrs = self._neighbors(pred_hash, enc_o, 'in')
+                if nbrs:
+                    for subj in nbrs:
+                        yield (decode_term(subj), p_term, o), self._contexts()
+            else:
+                for subj, obj in self._iter_edges(pred_hash):
+                    yield (decode_term(subj), p_term, decode_term(obj)), \
+                        self._contexts()
+
+    def __len__(self, context=None):
+        return sum(1 for _ in self.triples((None, None, None)))
+
+    # === Store write interface ===
+
+    def add(self, triple, context, quoted=False):
+        s, p, o = triple
+        self._graph().put(encode_term(s), encode_term(p), encode_term(o))
+
+    def addN(self, quads):
+        batch = [(encode_term(s), encode_term(p), encode_term(o))
+                 for s, p, o, _ in quads]
+        if batch:
+            self._graph().put_batch(batch)
+
+    def remove(self, triple_pattern, context=None):
+        # Materialize matches first: don't mutate tables mid-scan.
+        matched = [t for t, _ in self.triples(triple_pattern, context)]
+        g = self._graph()
+        g.cog.use_namespace(g.graph_name)
+        for s, p, o in matched:
+            g.delete(encode_term(s), encode_term(p), encode_term(o))
+
+    # === Namespace persistence (in-memory, per session) ===
+
+    def bind(self, prefix, namespace, override=True):
+        bound_namespace = self.__namespace.get(prefix)
+        bound_prefix = self.__prefix.get(namespace)
+        if override:
+            if bound_prefix is not None:
+                del self.__namespace[bound_prefix]
+            if bound_namespace is not None:
+                del self.__prefix[bound_namespace]
+            self.__prefix[namespace] = prefix
+            self.__namespace[prefix] = namespace
+        else:
+            self.__prefix[bound_namespace or namespace] = bound_prefix or prefix
+            self.__namespace[bound_prefix or prefix] = bound_namespace or namespace
+
+    def namespace(self, prefix):
+        return self.__namespace.get(prefix)
+
+    def prefix(self, namespace):
+        return self.__prefix.get(namespace)
+
+    def namespaces(self):
+        for prefix, namespace in self.__namespace.items():
+            yield prefix, namespace

--- a/cog/rdf_terms.py
+++ b/cog/rdf_terms.py
@@ -1,0 +1,66 @@
+"""
+Term codec: the mapping between rdflib terms and CogDB stored strings.
+
+CogDB stores vertex ids and predicate names as plain strings. RDF terms are
+richer — an IRI, a blank node, or a literal carrying an optional language tag
+or datatype. This module defines the single, bidirectional rule for moving
+between the two so that distinct RDF terms are always distinct stored strings
+and every stored string decodes back to exactly one term.
+
+Encoding rules (N-Triples syntax for literals and blank nodes, bare for IRIs):
+
+    URIRef("alice")                     <->  alice
+    URIRef("http://ex/alice")           <->  http://ex/alice
+    Literal("chat")                     <->  "chat"            (quotes kept)
+    Literal("chat", lang="fr")          <->  "chat"@fr
+    Literal("42", datatype=xsd:integer) <->  "42"^^<http://www.w3.org/2001/XMLSchema#integer>
+    BNode("b0")                         <->  _:b0
+
+IRIs are stored bare (no angle brackets) so the two query surfaces see one
+graph: a triple written with the Torque API — g.put("alice", "follows",
+"bob") — is queryable from SPARQL as { <alice> <follows> ?x }, and an IRI
+written through rdflib is addressable from Torque as g.v("http://ex/alice").
+Vertex ids of existing graphs therefore decode as IRIs. Blank-node ids
+created by put_json() already use the _:label convention and decode as
+blank nodes.
+
+RFC 3987 forbids the characters '"', "'" and the "_:" prefix shape in IRIs,
+so real IRIs never collide with the literal/blank-node encodings. A URIRef
+that nevertheless starts with one of these (only constructible by hand) is
+stored as-is and will not round-trip; everything else is bijective.
+"""
+from functools import lru_cache
+
+from rdflib import BNode, Literal, URIRef
+from rdflib.util import from_n3
+
+
+def encode_term(term):
+    """Encode an rdflib term to its CogDB stored-string form."""
+    # Order matters: URIRef, Literal and BNode are all str subclasses.
+    if isinstance(term, URIRef):
+        return str(term)
+    if isinstance(term, (Literal, BNode)):
+        return term.n3()
+    raise TypeError(
+        "expected an rdflib URIRef, Literal or BNode, got {!r}".format(term))
+
+
+@lru_cache(maxsize=65536)
+def decode_term(stored):
+    """Decode a CogDB stored string back to an rdflib term."""
+    if stored.startswith(('"', "'")):
+        try:
+            term = from_n3(stored)
+        except Exception:
+            term = None
+        # from_n3 is lenient and can misparse strings that are not valid
+        # N-Triples syntax. Accept the parse only if it reproduces the
+        # stored string exactly; otherwise this is a legacy vertex id that
+        # merely starts with a quote character, kept as a bare id.
+        if isinstance(term, Literal) and term.n3() == stored:
+            return term
+        return URIRef(stored)
+    if stored.startswith("_:"):
+        return BNode(stored[2:])
+    return URIRef(stored)

--- a/cog/torque.py
+++ b/cog/torque.py
@@ -1401,8 +1401,6 @@ class Graph(EmbeddingMixin, TraversalMixin):
         """
         Return an rdflib.Graph view over this graph.
 
-        Requires the optional rdflib dependency: pip install cogdb[sparql]
-
         The returned graph reads and writes the same storage as Torque —
         triples added through rdflib (e.g. rdf().parse(...)) are visible to
         Torque traversals and vice versa. Term conversion rules are
@@ -1425,9 +1423,11 @@ class Graph(EmbeddingMixin, TraversalMixin):
             try:
                 import rdflib
             except ImportError:
+                # rdflib ships with cogdb; this only triggers on stripped
+                # installs (e.g. pip install --no-deps).
                 raise ImportError(
-                    "RDF/SPARQL support requires the optional rdflib "
-                    "dependency. Install it with: pip install cogdb[sparql]")
+                    "rdflib is required for RDF/SPARQL support. "
+                    "Install it with: pip install rdflib")
             from cog.rdf_store import CogStore
             self._rdf_graph = rdflib.Graph(
                 store=CogStore(self),
@@ -1437,8 +1437,6 @@ class Graph(EmbeddingMixin, TraversalMixin):
     def sparql(self, query, init_bindings=None, init_ns=None):
         """
         Run a SPARQL 1.1 query against this graph.
-
-        Requires the optional rdflib dependency: pip install cogdb[sparql]
 
         Torque-written vertices are addressable as IRIs: g.put("alice",
         "follows", "bob") matches the pattern { <alice> <follows> ?x }.
@@ -1469,8 +1467,6 @@ class Graph(EmbeddingMixin, TraversalMixin):
         """
         Load an RDF document (Turtle, N-Triples, RDF/XML, JSON-LD, ...) into
         the graph using rdflib's parsers, in batch mode.
-
-        Requires the optional rdflib dependency: pip install cogdb[sparql]
 
         :param source: File path, URL, or file-like object.
         :param format: Optional rdflib format name ("turtle", "nt", "xml",

--- a/cog/torque.py
+++ b/cog/torque.py
@@ -1395,6 +1395,100 @@ class Graph(EmbeddingMixin, TraversalMixin):
         from cog.export import export_triples
         return export_triples(self, filepath, fmt=fmt, strict=strict)
 
+    # === RDF / SPARQL (optional, requires rdflib) ===
+
+    def rdf(self):
+        """
+        Return an rdflib.Graph view over this graph.
+
+        Requires the optional rdflib dependency: pip install cogdb[sparql]
+
+        The returned graph reads and writes the same storage as Torque —
+        triples added through rdflib (e.g. rdf().parse(...)) are visible to
+        Torque traversals and vice versa. Term conversion rules are
+        documented in cog.rdf_terms.
+
+        :return: An rdflib.Graph backed by this CogDB graph.
+
+        Example:
+            rg = g.rdf()
+            rg.parse("data.ttl")                       # load Turtle
+            rg.serialize("out.ttl", format="turtle")   # export Turtle
+            for row in rg.query("SELECT ?s WHERE { ?s ?p ?o }"):
+                print(row.s)
+        """
+        if self._cloud:
+            raise NotImplementedError(
+                "RDF/SPARQL is not available in cloud mode yet. "
+                "Open the graph locally to use sparql()/rdf().")
+        if getattr(self, "_rdf_graph", None) is None:
+            try:
+                import rdflib
+            except ImportError:
+                raise ImportError(
+                    "RDF/SPARQL support requires the optional rdflib "
+                    "dependency. Install it with: pip install cogdb[sparql]")
+            from cog.rdf_store import CogStore
+            self._rdf_graph = rdflib.Graph(
+                store=CogStore(self),
+                identifier=rdflib.URIRef("cogdb:{}".format(self.graph_name)))
+        return self._rdf_graph
+
+    def sparql(self, query, init_bindings=None, init_ns=None):
+        """
+        Run a SPARQL 1.1 query against this graph.
+
+        Requires the optional rdflib dependency: pip install cogdb[sparql]
+
+        Torque-written vertices are addressable as IRIs: g.put("alice",
+        "follows", "bob") matches the pattern { <alice> <follows> ?x }.
+
+        :param query: SPARQL query string (SELECT, ASK, CONSTRUCT, DESCRIBE).
+        :param init_bindings: Optional dict of initial variable bindings.
+        :param init_ns: Optional dict of prefix -> namespace for the query.
+        :return: SELECT/ASK: dict in W3C SPARQL 1.1 JSON Results format
+                 (https://www.w3.org/TR/sparql11-results-json/).
+                 CONSTRUCT/DESCRIBE: list of (s, p, o) tuples in N3 syntax.
+
+        Example:
+            g.put("alice", "follows", "bob")
+            g.sparql("SELECT ?x WHERE { <alice> <follows> ?x }")
+            # {'head': {'vars': ['x']},
+            #  'results': {'bindings': [{'x': {'type': 'uri', 'value': 'bob'}}]}}
+        """
+        result = self.rdf().query(
+            query, initBindings=init_bindings or {}, initNs=init_ns or {})
+        if result.type in ("SELECT", "ASK"):
+            data = result.serialize(format="json")
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            return json.loads(data)
+        return [(s.n3(), p.n3(), o.n3()) for s, p, o in result]
+
+    def load_rdf(self, source, format=None):
+        """
+        Load an RDF document (Turtle, N-Triples, RDF/XML, JSON-LD, ...) into
+        the graph using rdflib's parsers, in batch mode.
+
+        Requires the optional rdflib dependency: pip install cogdb[sparql]
+
+        :param source: File path, URL, or file-like object.
+        :param format: Optional rdflib format name ("turtle", "nt", "xml",
+                       "json-ld", ...). Guessed from the file extension when
+                       omitted.
+        :return: self for method chaining.
+
+        Example:
+            g.load_rdf("people.ttl")
+            g.v("http://example.org/alice").out().all()
+        """
+        rdf_graph = self.rdf()  # raises with install hint if rdflib missing
+        import rdflib
+        parsed = rdflib.Graph()
+        parsed.parse(source=source, format=format)
+        rdf_graph.store.addN((s, p, o, None) for s, p, o in parsed)
+        return self
+
     def view(self, view_name, persist=True):
         """
         Returns an interactive D3.js graph view of the query result.

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
     author_email='hello@cogdb.io',
     license='MIT',
     packages=['cog'],
-    install_requires=['xxhash>=3.2.0', 'simsimd>=5.0.0', 'websocket-client>=1.9.0', 'certifi'],
+    install_requires=['xxhash>=3.2.0', 'simsimd>=5.0.0', 'websocket-client>=1.9.0', 'certifi',
+                      'rdflib>=7.0'],
     extras_require={
-        'dev': ['pytest', 'pytest-cov', 'rdflib>=7.0'],
-        'sparql': ['rdflib>=7.0'],
+        'dev': ['pytest', 'pytest-cov'],
     },
     entry_points={
         'rdf.plugins.store': [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,13 @@ setup(
     packages=['cog'],
     install_requires=['xxhash>=3.2.0', 'simsimd>=5.0.0', 'websocket-client>=1.9.0', 'certifi'],
     extras_require={
-        'dev': ['pytest', 'pytest-cov'],
+        'dev': ['pytest', 'pytest-cov', 'rdflib>=7.0'],
+        'sparql': ['rdflib>=7.0'],
+    },
+    entry_points={
+        'rdf.plugins.store': [
+            'cogdb = cog.rdf_store:CogStore',
+        ],
     },
     python_requires='>=3.8',
     zip_safe=False,

--- a/test/test_sparql.py
+++ b/test/test_sparql.py
@@ -1,0 +1,393 @@
+import os
+import shutil
+import unittest
+
+import pytest
+
+rdflib = pytest.importorskip("rdflib", reason="SPARQL tests require the optional rdflib dependency")
+
+from rdflib import BNode, Literal, URIRef
+from rdflib.namespace import XSD
+
+from cog.rdf_terms import decode_term, encode_term
+from cog.torque import Graph
+
+DIR_NAME = "SparqlTest"
+
+
+def graph_home(name):
+    path = "/tmp/" + name
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    return name
+
+
+class TermCodecTest(unittest.TestCase):
+    """encode_term/decode_term must be bijective across all term kinds."""
+
+    def test_round_trip_all_kinds(self):
+        terms = [
+            URIRef("alice"),
+            URIRef("http://example.org/alice"),
+            Literal("chat"),
+            Literal("chat", lang="fr"),
+            Literal("42", datatype=XSD.integer),
+            Literal(29),
+            Literal(4.5),
+            Literal(True),
+            Literal('he said "hi"\nbye'),
+            BNode("b0"),
+            BNode("1654006783197959000lIxa"),  # put_json style label
+        ]
+        for term in terms:
+            stored = encode_term(term)
+            self.assertIsInstance(stored, str)
+            self.assertEqual(decode_term(stored), term,
+                             "decode(encode(t)) != t for {!r} (stored as {!r})".format(term, stored))
+
+    def test_distinct_terms_distinct_strings(self):
+        terms = [
+            Literal("chat"),
+            Literal("chat", lang="fr"),
+            Literal("chat", lang="en"),
+            URIRef("chat"),
+            Literal("chat", datatype=XSD.string),
+            BNode("chat"),
+        ]
+        encoded = [encode_term(t) for t in terms]
+        self.assertEqual(len(set(encoded)), len(terms), "term encodings collided: " + str(encoded))
+
+    def test_bare_torque_strings_decode_as_iris(self):
+        self.assertEqual(decode_term("alice"), URIRef("alice"))
+        self.assertEqual(decode_term("http://example.org/x"), URIRef("http://example.org/x"))
+
+    def test_putj_blank_node_ids_decode_as_bnodes(self):
+        self.assertEqual(decode_term("_:id_user1"), BNode("id_user1"))
+
+    def test_legacy_junk_never_raises(self):
+        # A vertex id that merely starts with a quote but is not valid N3.
+        self.assertEqual(decode_term('"unclosed'), URIRef('"unclosed'))
+
+    def test_encode_rejects_non_terms(self):
+        with self.assertRaises(TypeError):
+            encode_term("plain string")
+        with self.assertRaises(TypeError):
+            encode_term(29)
+
+
+class CogStoreTest(unittest.TestCase):
+    """Pattern dispatch and write-through at the rdflib Graph level."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.g = Graph(graph_name="store_test", cog_home=graph_home("SparqlStoreTest"))
+        cls.rg = cls.g.rdf()
+        cls.alice = URIRef("http://ex/alice")
+        cls.bob = URIRef("http://ex/bob")
+        cls.fred = URIRef("http://ex/fred")
+        cls.knows = URIRef("http://ex/knows")
+        cls.name = URIRef("http://ex/name")
+        cls.rg.add((cls.alice, cls.knows, cls.bob))
+        cls.rg.add((cls.bob, cls.knows, cls.fred))
+        cls.rg.add((cls.alice, cls.name, Literal("Alice")))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.g.close()
+        shutil.rmtree("/tmp/SparqlStoreTest", ignore_errors=True)
+
+    def _match(self, pattern):
+        return set(self.rg.triples(pattern))
+
+    def test_all_eight_pattern_shapes(self):
+        a, k, b = self.alice, self.knows, self.bob
+        # (s, p, o)
+        self.assertEqual(self._match((a, k, b)), {(a, k, b)})
+        # (s, p, ?)
+        self.assertEqual(self._match((a, k, None)), {(a, k, b)})
+        # (?, p, o)
+        self.assertEqual(self._match((None, k, b)), {(a, k, b)})
+        # (?, p, ?)
+        self.assertEqual(self._match((None, k, None)),
+                         {(a, k, b), (b, k, self.fred)})
+        # (s, ?, ?)
+        self.assertEqual(self._match((a, None, None)),
+                         {(a, k, b), (a, self.name, Literal("Alice"))})
+        # (s, ?, o)
+        self.assertEqual(self._match((a, None, b)), {(a, k, b)})
+        # (?, ?, o)
+        self.assertEqual(self._match((None, None, b)), {(a, k, b)})
+        # (?, ?, ?)
+        self.assertEqual(len(self._match((None, None, None))), 3)
+
+    def test_len(self):
+        self.assertEqual(len(self.rg), 3)
+
+    def test_no_match_returns_empty(self):
+        self.assertEqual(self._match((self.fred, self.knows, None)), set())
+        self.assertEqual(self._match((None, URIRef("http://ex/none"), None)), set())
+
+    def test_missing_predicate_lookup_creates_no_files(self):
+        graph_dir = self.g.config.cog_data_dir(self.g.graph_name)
+        before = set(os.listdir(graph_dir))
+        list(self.rg.triples((None, URIRef("http://ex/ghost_predicate"), None)))
+        self.g.sparql("SELECT ?x WHERE { <nope> <http://ex/ghost_predicate> ?x }")
+        after = set(os.listdir(graph_dir))
+        self.assertEqual(before, after, "querying a missing predicate created table files")
+
+    def test_write_via_rdflib_visible_to_torque(self):
+        result = self.g.v("http://ex/alice").out("http://ex/knows").all()
+        self.assertEqual([v["id"] for v in result["result"]], ["http://ex/bob"])
+
+
+class SparqlQueryTest(unittest.TestCase):
+    """SPARQL over Torque-written data — the interop path."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.g = Graph(graph_name="people", cog_home=graph_home("SparqlQueryTest"))
+        cls.g.put("alice", "follows", "bob")
+        cls.g.put("bob", "follows", "fred")
+        cls.g.put("dani", "follows", "bob")
+        cls.g.put("alice", "status", "cool_person")
+        cls.g.put("fred", "status", "cool_person")
+        # typed and tagged literals via the RDF surface
+        rg = cls.g.rdf()
+        rg.add((URIRef("alice"), URIRef("age"), Literal(29)))
+        rg.add((URIRef("bob"), URIRef("age"), Literal(35)))
+        rg.add((URIRef("alice"), URIRef("greeting"), Literal("chat", lang="fr")))
+        rg.add((URIRef("bob"), URIRef("greeting"), Literal("chat")))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.g.close()
+        shutil.rmtree("/tmp/SparqlQueryTest", ignore_errors=True)
+
+    def bindings(self, result):
+        return result["results"]["bindings"]
+
+    def values(self, result, var):
+        return sorted(b[var]["value"] for b in self.bindings(result))
+
+    def test_select_over_torque_data(self):
+        res = self.g.sparql("SELECT ?x WHERE { <alice> <follows> ?x }")
+        self.assertEqual(res["head"]["vars"], ["x"])
+        self.assertEqual(self.bindings(res), [{"x": {"type": "uri", "value": "bob"}}])
+
+    def test_join_two_hops(self):
+        res = self.g.sparql("SELECT ?x WHERE { <alice> <follows> ?y . ?y <follows> ?x }")
+        self.assertEqual(self.values(res, "x"), ["fred"])
+
+    def test_reverse_lookup(self):
+        res = self.g.sparql("SELECT ?who WHERE { ?who <follows> <bob> }")
+        self.assertEqual(self.values(res, "who"), ["alice", "dani"])
+
+    def test_variable_predicate(self):
+        res = self.g.sparql("SELECT ?p WHERE { <alice> ?p <bob> }")
+        self.assertEqual(self.values(res, "p"), ["follows"])
+
+    def test_filter_on_typed_literal(self):
+        res = self.g.sparql(
+            "SELECT ?who WHERE { ?who <age> ?age FILTER(?age > 30) }")
+        self.assertEqual(self.values(res, "who"), ["bob"])
+
+    def test_language_tags_do_not_merge(self):
+        res = self.g.sparql('SELECT ?who WHERE { ?who <greeting> "chat" }')
+        self.assertEqual(self.values(res, "who"), ["bob"])
+        res = self.g.sparql('SELECT ?who WHERE { ?who <greeting> "chat"@fr }')
+        self.assertEqual(self.values(res, "who"), ["alice"])
+
+    def test_optional(self):
+        res = self.g.sparql(
+            "SELECT ?x ?age WHERE { <alice> <follows> ?x OPTIONAL { ?x <age> ?age } }")
+        rows = self.bindings(res)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["x"]["value"], "bob")
+        self.assertEqual(rows[0]["age"]["value"], "35")
+
+    def test_union(self):
+        res = self.g.sparql(
+            "SELECT ?x WHERE { { <alice> <follows> ?x } UNION { <bob> <follows> ?x } }")
+        self.assertEqual(self.values(res, "x"), ["bob", "fred"])
+
+    def test_order_limit(self):
+        res = self.g.sparql(
+            "SELECT ?s WHERE { ?s <follows> ?o } ORDER BY ?s LIMIT 2")
+        self.assertEqual([b["s"]["value"] for b in self.bindings(res)], ["alice", "bob"])
+
+    def test_count_aggregate(self):
+        res = self.g.sparql(
+            "SELECT (COUNT(?x) AS ?n) WHERE { ?x <status> <cool_person> }")
+        self.assertEqual(self.values(res, "n"), ["2"])
+
+    def test_property_path(self):
+        res = self.g.sparql("SELECT ?x WHERE { <alice> <follows>+ ?x }")
+        self.assertEqual(self.values(res, "x"), ["bob", "fred"])
+
+    def test_ask(self):
+        self.assertTrue(self.g.sparql("ASK { <alice> <follows> <bob> }")["boolean"])
+        self.assertFalse(self.g.sparql("ASK { <bob> <follows> <alice> }")["boolean"])
+
+    def test_construct_returns_n3_triples(self):
+        triples = self.g.sparql(
+            "CONSTRUCT { ?x <knows> ?y } WHERE { ?x <follows> ?y }")
+        self.assertIn(("<alice>", "<knows>", "<bob>"), triples)
+        self.assertEqual(len(triples), 3)
+
+    def test_init_ns_and_bindings(self):
+        res = self.g.sparql(
+            "SELECT ?x WHERE { ?who ex:follows ?x }",
+            init_ns={"ex": ""},
+            init_bindings={"who": URIRef("alice")})
+        self.assertEqual(self.values(res, "x"), ["bob"])
+
+    def test_differential_against_rdflib_memory_store(self):
+        """Same triples, same queries: CogStore must agree with rdflib's
+        own in-memory store."""
+        mem = rdflib.Graph()
+        for t in self.g.rdf():
+            mem.add(t)
+        queries = [
+            "SELECT ?s ?o WHERE { ?s <follows> ?o }",
+            "SELECT ?s WHERE { ?s <follows> ?y . ?y <follows> ?o }",
+            "SELECT ?s ?p ?o WHERE { ?s ?p ?o }",
+            "SELECT ?s WHERE { ?s <age> ?a FILTER(?a >= 29) }",
+            "SELECT ?x WHERE { <alice> <follows>* ?x }",
+        ]
+        for q in queries:
+            cog_rows = sorted(map(str, self.g.rdf().query(q)))
+            mem_rows = sorted(map(str, mem.query(q)))
+            self.assertEqual(cog_rows, mem_rows, "engines disagree on: " + q)
+
+
+class SparqlMutationTest(unittest.TestCase):
+    """remove()/delete paths get a fresh graph per test."""
+
+    def setUp(self):
+        self.g = Graph(graph_name="mut", cog_home=graph_home("SparqlMutationTest"))
+        self.rg = self.g.rdf()
+        self.rg.add((URIRef("a"), URIRef("p"), URIRef("b")))
+        self.rg.add((URIRef("a"), URIRef("p"), URIRef("c")))
+        self.rg.add((URIRef("a"), URIRef("q"), Literal("x")))
+
+    def tearDown(self):
+        self.g.close()
+        shutil.rmtree("/tmp/SparqlMutationTest", ignore_errors=True)
+
+    def test_remove_specific_triple(self):
+        self.rg.remove((URIRef("a"), URIRef("p"), URIRef("b")))
+        self.assertEqual(len(self.rg), 2)
+        self.assertFalse(self.g.sparql("ASK { <a> <p> <b> }")["boolean"])
+        self.assertTrue(self.g.sparql("ASK { <a> <p> <c> }")["boolean"])
+
+    def test_remove_with_wildcards(self):
+        self.rg.remove((URIRef("a"), URIRef("p"), None))
+        self.assertEqual(len(self.rg), 1)
+        self.assertTrue(self.g.sparql("ASK { <a> <q> ?x }")["boolean"])
+
+    def test_torque_delete_visible_to_sparql(self):
+        self.g.delete("a", "p", "b")
+        self.assertEqual(self.values(), ["c"])
+
+    def values(self):
+        res = self.g.sparql("SELECT ?x WHERE { <a> <p> ?x }")
+        return sorted(b["x"]["value"] for b in res["results"]["bindings"])
+
+
+class LoadRdfTest(unittest.TestCase):
+
+    TTL = """
+    @prefix ex: <http://example.org/> .
+    ex:alice ex:knows ex:bob ;
+             ex:name "Alice" ;
+             ex:age 29 .
+    ex:bob ex:knows ex:fred .
+    """
+
+    def setUp(self):
+        self.g = Graph(graph_name="ttl", cog_home=graph_home("SparqlLoadTest"))
+        self.ttl_path = "/tmp/SparqlLoadTest_data.ttl"
+        with open(self.ttl_path, "w") as f:
+            f.write(self.TTL)
+
+    def tearDown(self):
+        self.g.close()
+        shutil.rmtree("/tmp/SparqlLoadTest", ignore_errors=True)
+        os.remove(self.ttl_path)
+
+    def test_load_turtle_and_query_both_surfaces(self):
+        self.g.load_rdf(self.ttl_path)
+        # SPARQL surface
+        res = self.g.sparql(
+            "SELECT ?x WHERE { <http://example.org/alice> <http://example.org/knows>+ ?x }")
+        got = sorted(b["x"]["value"] for b in res["results"]["bindings"])
+        self.assertEqual(got, ["http://example.org/bob", "http://example.org/fred"])
+        # Torque surface sees the same vertices
+        torque = self.g.v("http://example.org/alice").out("http://example.org/knows").all()
+        self.assertEqual([v["id"] for v in torque["result"]], ["http://example.org/bob"])
+        # Typed literal survived the load
+        res = self.g.sparql(
+            "SELECT ?a WHERE { <http://example.org/alice> <http://example.org/age> ?a "
+            "FILTER(?a > 25) }")
+        self.assertEqual(len(res["results"]["bindings"]), 1)
+
+
+class SparqlDiskModeTest(unittest.TestCase):
+    """Same dispatch with the memory view disabled (pure disk reads)."""
+
+    def setUp(self):
+        self.g = Graph(graph_name="disk", cog_home=graph_home("SparqlDiskTest"),
+                       use_memory_view=False)
+        self.g.put("alice", "follows", "bob")
+        self.g.put("bob", "follows", "fred")
+
+    def tearDown(self):
+        self.g.close()
+        shutil.rmtree("/tmp/SparqlDiskTest", ignore_errors=True)
+
+    def test_select_join_on_disk(self):
+        res = self.g.sparql("SELECT ?x WHERE { <alice> <follows> ?y . ?y <follows> ?x }")
+        self.assertEqual([b["x"]["value"] for b in res["results"]["bindings"]], ["fred"])
+
+
+class BlankNodeInteropTest(unittest.TestCase):
+
+    def setUp(self):
+        self.g = Graph(graph_name="bn", cog_home=graph_home("SparqlBnodeTest"))
+
+    def tearDown(self):
+        self.g.close()
+        shutil.rmtree("/tmp/SparqlBnodeTest", ignore_errors=True)
+
+    def test_putj_objects_queryable_as_bnodes(self):
+        self.g.putj({"_id": "user1", "name": "bob", "city": "toronto"})
+        res = self.g.sparql("SELECT ?s WHERE { ?s <name> <bob> }")
+        rows = res["results"]["bindings"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["s"]["type"], "bnode")
+        res = self.g.sparql("SELECT ?city WHERE { ?s <name> <bob> . ?s <city> ?city }")
+        self.assertEqual(rows and res["results"]["bindings"][0]["city"]["value"], "toronto")
+
+
+class PluginRegistrationTest(unittest.TestCase):
+    """rdflib.Graph(store="cogdb") via the setuptools entry point."""
+
+    def test_open_by_name_through_plugin(self):
+        try:
+            rdflib.plugin.get("cogdb", rdflib.store.Store)
+        except rdflib.plugin.PluginException:
+            self.skipTest("cogdb store entry point not registered (package not pip-installed)")
+        shutil.rmtree("/tmp/cog_home/plugin_test", ignore_errors=True)
+        rg = rdflib.Graph(store="cogdb")
+        rg.open("plugin_test")
+        try:
+            rg.add((URIRef("a"), URIRef("p"), URIRef("b")))
+            rows = list(rg.query("SELECT ?o WHERE { <a> <p> ?o }"))
+            self.assertEqual(rows, [(URIRef("b"),)])
+        finally:
+            rg.store.cog_graph.close()
+            shutil.rmtree("/tmp/cog_home/plugin_test", ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_sparql.py
+++ b/test/test_sparql.py
@@ -4,7 +4,7 @@ import unittest
 
 import pytest
 
-rdflib = pytest.importorskip("rdflib", reason="SPARQL tests require the optional rdflib dependency")
+rdflib = pytest.importorskip("rdflib", reason="SPARQL tests require rdflib")
 
 from rdflib import BNode, Literal, URIRef
 from rdflib.namespace import XSD


### PR DESCRIPTION
Add SPARQL 1.1 support via rdflib store adapter

CogDB graphs are now queryable with standard SPARQL — SELECT, ASK,
CONSTRUCT, DESCRIBE, FILTER, OPTIONAL, UNION, aggregates and property
paths — through rdflib's query engine running over a new store
adapter. rdflib (pure Python, BSD-3) ships as a default dependency,
imported lazily: Torque-only usage pays no import or runtime cost.

New API:
- Graph.sparql(query): returns W3C SPARQL JSON results for SELECT/ASK,
  N3 triples for CONSTRUCT/DESCRIBE.
- Graph.rdf(): live rdflib.Graph view over the same storage, enabling
  Turtle/JSON-LD/RDF-XML serialization and the wider RDF ecosystem.
- Graph.load_rdf(source): batch-load RDF files via rdflib's parsers.
- rdflib.Graph(store="cogdb"): store plugin registered via entry point.